### PR TITLE
add almighty-ui per PR CI job and post-merge MASTER build jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -103,8 +103,19 @@
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
+        - '{ci_project}-{git_repo}':
+            git_username: almighty
+            git_repo: almighty-ui
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+
         - '{ci_project}-{git_repo}-build-master':
             git_username: almighty
             git_repo: almighty-core
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+        - '{ci_project}-{git_repo}-build-master':
+            git_username: almighty
+            git_repo: almighty-ui
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'


### PR DESCRIPTION
at the moment the jobs are not related, we might want to setup a dependancy down the road. Also the almighty-ui test script is just a stub that will always pass, with no build.