### PR TITLE
Forward Jenkins env vars to worker machine

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -55,7 +55,12 @@
             set +e
             export CICO_API_KEY=$(cat ~/duffy.key )
             read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            env | grep "JENKINS_URL" > ~/.ssh/environment
+            env | grep "GIT_BRANCH" >> ~/.ssh/environment
+            env | grep "GIT_COMMIT" >> ~/.ssh/environment
+            env | grep "BUILD_NUMBER" >> ~/.ssh/environment
+            env | grep "ghprb" >> ~/.ssh/environment
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -o PermitUserEnvironment=yes"
             ssh_cmd="ssh $sshopts $CICO_hostname"
             $ssh_cmd yum -y install rsync
             git rebase origin/${{ghprbTargetBranch}} \
@@ -87,7 +92,12 @@
             set +e
             export CICO_API_KEY=$(cat ~/duffy.key )
             read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            env | grep "JENKINS_URL" > ~/.ssh/environment
+            env | grep "GIT_BRANCH" >> ~/.ssh/environment
+            env | grep "GIT_COMMIT" >> ~/.ssh/environment
+            env | grep "BUILD_NUMBER" >> ~/.ssh/environment
+            env | grep "ghprb" >> ~/.ssh/environment
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root -o PermitUserEnvironment=yes"
             ssh_cmd="ssh $sshopts $CICO_hostname"
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload


### PR DESCRIPTION
For https://codecov.io/ to be able to detect a CI provider (Jenkins in this case) some environment variables need to be present. See [this script](https://github.com/codecov/codecov-bash/blob/e87e79f5c78e99f0a46ca55e07690776f641c7c8/codecov#L365) for more information about this. Codecov.io advocates the usage of this script: https://codecov.io/bash

The plan with this commit is to pass the environment variables from the jenkins slave to the worker machine.