### PR TITLE
add the almighty-bot credentials to the job template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -85,6 +85,7 @@
             url: https://github.com/{git_username}/{git_repo}/
     scm:
         - git:
+            credentials-id: "c4872223-4024-4cd4-8e09-1bbdc7d6e971"
             url: https://github.com/{git_username}/{git_repo}.git
             shallow_clone: true
             branches: 
@@ -121,6 +122,7 @@
     scm:
         - git:
             url: https://github.com/{git_username}/{git_repo}.git
+            credentials-id: "c4872223-4024-4cd4-8e09-1bbdc7d6e971"
             shallow_clone: true
             branches: 
                 - master

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -34,6 +34,7 @@
     name: git-scm
     scm:
         - git:
+            credentials-id: "c4872223-4024-4cd4-8e09-1bbdc7d6e971"
             url: "{git_url}"
             skip-tag: True
             git-tool: ci-git


### PR DESCRIPTION
These jobs need to use the appropriate credentials (in the jenkins
credential store) to be able to push to the repos on github.