### PR TITLE
we need to use the ci-git tool for this

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -125,6 +125,7 @@
         - git:
             url: https://github.com/{git_organization}/{git_repo}.git
             credentials-id: "c4872223-4024-4cd4-8e09-1bbdc7d6e971"
+            git-tool: ci-git
             shallow_clone: true
             branches: 
                 - trycommit


### PR DESCRIPTION
If we don't, then git does not set the credentials properly within Jenkins.