### PR TITLE
the github user should be almighty-bot

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -3,7 +3,7 @@
     timeout: '15m'
     jobdescription: "Managed by Jenkins Job Builder, do not edit manually!"
     git_organization: almighty
-    github_user: almigthy-bot
+    github_user: almighty-bot
     
 - trigger:
     name: githubprb


### PR DESCRIPTION
Clones would happen unauthenticated, but providing almigthy-bot(sic) would
break push in jenkins by overriding the provided credentials