### PR TITLE
force-push to gh-pages as it's not a history

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -157,6 +157,7 @@
       - git:
           push-only-if-success: true
           push-merge: true
+          force-push: true
           branches:
             - branch:
                 remote: origin


### PR DESCRIPTION
gh-pages is just a publishing mechanism, it doesn't track source