### PR TITLE
 start building per PR for fabric8-ui

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -162,9 +162,6 @@
             - branch:
                 remote: origin
                 name: "gh-pages"
-  
-          
-
 
 - project:
     name: devtools
@@ -181,6 +178,12 @@
             timeout: '20m'
         - '{ci_project}-{git_repo}':
             git_repo: almighty-devdoc
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'
+        - '{ci_project}-{git_repo}':
+            git_organization: fabric8
+            git_repo: fabric8-ui
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'


### PR DESCRIPTION
Start doing CI builds for fabric8-ui, the cico_run_tests.sh script looks intact in the repo, so we should get the work started, although the functional content under the script still needs work ( eg. the testing framework looks to be different ).