### PR TITLE
add job for deploying fabric8 ui

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -208,5 +208,11 @@
             svc_name: ui
             timeout: '20m'
         
-            
+	- '{ci_project}-{git_repo}-build-master':
+            git_organization: fabric8io
+            git_repo: fabric8-ui
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            svc_name: ui
+            timeout: '20m'
         


### PR DESCRIPTION
Update ci index to add job for deploying changes committed to fabricu-ui's master branch.