### PR TITLE
Che build: use unsafe-perm when executing npm install

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -102,7 +102,7 @@
             $ssh_cmd -t "git clone https://github.com/eclipse/che"
             $ssh_cmd -t "cd che && export NPM_CONFIG_PREFIX=~/.che_node_modules && \
                          export PATH=$NPM_CONFIG_PREFIX/bin:$PATH && \
-                         scl enable rh-nodejs4 'npm install -g bower gulp typings' && \
+                         scl enable rh-nodejs4 'npm install --unsafe-perm -g bower gulp typings' && \
                          scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast' "
             rtn_code=$?
             cico node done $CICO_ssid


### PR DESCRIPTION
Che build currently fails with error:

> Cannot run program "typings" (in directory "/root/che/dashboard"): error=2, No such file or directory

This may be a permission problem and may be solved using option [unsafe-perm](https://docs.npmjs.com/misc/config#unsafe-perm)