### PR TITLE
Added status_context_extra

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -5,6 +5,7 @@
     git_organization: almighty
     github_user: almighty-bot
     sub_job: ''
+    sub_job_status_context: ''
     
 - trigger:
     name: githubprb
@@ -36,7 +37,7 @@
           permit-all: false
           trigger-phrase: '.*\[test\].*'
           allow-whitelist-orgs-as-admins: true
-          status-context: "ci.centos.org PR build"
+          status-context: "ci.centos.org PR build{sub_job_status_context}"
 - scm:
     name: git-scm
     scm:
@@ -203,12 +204,14 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
+            sub_job_status_context: ' Tests without coverage'
         - '{ci_project}-{git_repo}{sub_job}':
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '20m'
             sub_job: '-coverage'
+            sub_job_status_context: ' Coverate calculation'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io
             git_repo: fabric8-planner

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -211,7 +211,7 @@
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '20m'
             sub_job: '-coverage'
-            sub_job_status_context: ' Coverate calculation'
+            sub_job_status_context: ' Tests with coverage'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io
             git_repo: fabric8-planner

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -5,7 +5,7 @@
     git_organization: almighty
     github_user: almighty-bot
     sub_job: ''
-    sub_job_status_context: ''
+    status_context_extra: ''
     
 - trigger:
     name: githubprb
@@ -37,7 +37,7 @@
           permit-all: false
           trigger-phrase: '.*\[test\].*'
           allow-whitelist-orgs-as-admins: true
-          status-context: "ci.centos.org PR build{sub_job_status_context}"
+          status-context: "ci.centos.org PR build{status_context_extra}"
 - scm:
     name: git-scm
     scm:
@@ -204,14 +204,14 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
-            sub_job_status_context: ' Tests without coverage'
+            status_context_extra: ' Tests without coverage'
         - '{ci_project}-{git_repo}{sub_job}':
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
             timeout: '20m'
             sub_job: '-coverage'
-            sub_job_status_context: ' Tests with coverage'
+            status_context_extra: ' Tests with coverage'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io
             git_repo: fabric8-planner


### PR DESCRIPTION
In order to distinguish jobs that protect a branch on github (here: https://github.com/almighty/almighty-core/settings/branches/master) I had to add an optional extra status context field.