### PR TITLE
Added {ci_project}-{git_repo}-coverage job template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -5,39 +5,47 @@
     git_organization: almighty
     github_user: almighty-bot
     sub_job: ''
-    status_context_extra: ''
-    
+
+- admin_list_defaults: &admin_list_defaults
+    name: 'admin_list_defaults'
+    admin-list:
+        - kbsingh
+        - aslakknutsen
+        - kwk
+        - sbose78
+        - tsmaeder
+        - maxandersen
+        - bartoszmajsak
+        - pmuir
+        - pranavgore09
+        - baijum
+        - DhritiShikhar
+        - joshuawilson
+        - Ritsyy
+        - sanbornsen
+        - nimishamukherjee
+        - SMahil
+        - xcoulon
+        - alexeykazakov
+        - michaelkleinhenz
+        - ppitonak
+
+- github_pull_request_defaults: &github_pull_request_defaults
+    name: 'github_pull_request_defaults'  
+    <<: *admin_list_defaults
+    cron: '* * * * *'
+    github-hooks: false
+    permit-all: false
+    trigger-phrase: '.*\[test\].*'
+    allow-whitelist-orgs-as-admins: true
+    status-context: "ci.centos.org PR build"
+
 - trigger:
     name: githubprb
     triggers:
       - github-pull-request:
-          admin-list:
-              - kbsingh
-              - aslakknutsen
-              - kwk
-              - sbose78
-              - tsmaeder
-              - maxandersen
-              - bartoszmajsak
-              - pmuir
-              - pranavgore09
-              - baijum
-              - DhritiShikhar
-              - joshuawilson
-              - Ritsyy
-              - sanbornsen
-              - nimishamukherjee
-              - SMahil
-              - xcoulon
-              - alexeykazakov
-              - michaelkleinhenz
-              - ppitonak
-          cron: '* * * * *'
-          github-hooks: false
-          permit-all: false
-          trigger-phrase: '.*\[test\].*'
-          allow-whitelist-orgs-as-admins: true
-          status-context: "ci.centos.org PR build{status_context_extra}"
+          <<: *github_pull_request_defaults
+        
 - scm:
     name: git-scm
     scm:
@@ -50,8 +58,8 @@
             branches:
                 - '${{ghprbActualCommit}}'
 
-- job-template:
-    name: '{ci_project}-{git_repo}'
+- job_template_defaults: &job_template_defaults
+    name: 'job_template_defaults'
     description: |
       {jobdescription}
     node: "{ci_project}"
@@ -85,38 +93,16 @@
             exit $rtn_code
 
 - job-template:
-    name: '{ci_project}-{git_repo}-{sub_job}'
-    description: |
-      {jobdescription}
-    node: "{ci_project}"
-    concurrent: true
-    properties:
-        - github:
-            url: https://github.com/{git_organization}/{git_repo}/
-    scm:
-        - git-scm:
-            git_url: https://{github_user}@github.com/{git_organization}/{git_repo}.git
+    name: '{ci_project}-{git_repo}'
+    <<: *job_template_defaults
+
+- job-template:
+    name: '{ci_project}-{git_repo}-coverage'
     triggers:
-        - githubprb
-    builders:
-        - shell: |
-            # testing out the cico client
-            set +e
-            export CICO_API_KEY=$(cat ~/duffy.key )
-            read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
-            ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
-            $ssh_cmd yum -y install rsync
-            git rebase origin/${{ghprbTargetBranch}} \
-            && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
-            && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
-            rtn_code=$?
-            cico node done $CICO_ssid
-            if [[ $rtn_code -eq 124 ]]; then
-               echo "BUILD TIMEOUT";
-            fi
-            exit $rtn_code
+      - github-pull-request:
+          status-context: "ci.centos.org PR build (coverage)"
+          <<: *github_pull_request_defaults
+    <<: *job_template_defaults
 
 - job-template:
     name: '{ci_project}-che-build-master'
@@ -239,7 +225,7 @@
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
             status_context_extra: ' Tests without coverage'
-        - '{ci_project}-{git_repo}-{sub_job}':
+        - '{ci_project}-{git_repo}-coverage':
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'


### PR DESCRIPTION
The `{ci_project}-{git_repo}-coverage` re-uses most of the
`{ci_project}-{git_repo}` template. In order to avoid code duplication
I've used ["YAML anchors and aliases"](http://docs.openstack.org/infra/jenkins-job-builder/definition.html#yaml-anchors-aliases) and created these defaults:

- `job_template_defaults`
- `github_pull_request_defaults`
- `admin_list_defaults`

The `github_pull_request_defaults` was created in order to use a different
commit status text for the coverage job template.