### PR TITLE
drop the che specific template, use the regular build-master template

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -104,32 +104,6 @@
           <<: *github_pull_request_defaults
     <<: *job_template_defaults
 
-- job-template:
-    name: '{ci_project}-che-build-master'
-    description: |
-      {jobdescription}
-    node: "{ci_project}"
-    triggers:
-        - timed: '20 00,12 * * *'
-    builders:
-        - shell: |
-            # testing out the cico client
-            set +e
-            export CICO_API_KEY=$(cat ~/duffy.key )
-            read CICO_hostname CICO_ssid <<< $(cico node get -f value -c ip_address -c comment)
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
-            ssh_cmd="ssh $sshopts $CICO_hostname"
-            $ssh_cmd -t "yum -y install centos-release-scl java-1.8.0-openjdk-devel git patch bzip2 golang"
-            $ssh_cmd -t "yum -y install rh-maven33 rh-nodejs4"
-            $ssh_cmd -t "git clone https://github.com/eclipse/che"
-            $ssh_cmd -t "cd che && export NPM_CONFIG_PREFIX=~/.che_node_modules && \
-                         export PATH=$NPM_CONFIG_PREFIX/bin:$PATH && \
-                         scl enable rh-nodejs4 'npm install --unsafe-perm -g bower gulp typings' && \
-                         scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast' "
-            rtn_code=$?
-            cico node done $CICO_ssid
-            exit $rtn_code
-            
 
 - job-template:
     name: '{ci_project}-{git_repo}-build-master'
@@ -274,7 +248,10 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: f8ui
             timeout: '20m'
-        - '{ci_project}-che-build-master':
-            git_organisation: eclipse
-            git_repo: che
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: kbsingh
+            git_repo: build-run-che
             ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build.sh && /bin/bash cico_deploy.sh'
+            svc_name: che
+            timeout: '30m'


### PR DESCRIPTION
we dont need all the build commands in the job file, abstracting that away into its own git repo for now.