### PR TITLE
Use --preserve-merges when rebasing

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -84,7 +84,7 @@
             ssh_cmd="ssh $sshopts $CICO_hostname"
             env > jenkins-env
             $ssh_cmd yum -y install rsync
-            git rebase origin/${{ghprbTargetBranch}} \
+            git rebase --preserve-merges origin/${{ghprbTargetBranch}} \
             && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?


### PR DESCRIPTION
This should solve conflicts with PRs where the author already did merge master in his or her topic branches. This PR for example has problems when rebasing onto master in CI even though master was merged into the topic branch: https://github.com/almighty/almighty-core/pull/619.

Here's the manual passage from `git rebase`:

```
       -p, --preserve-merges
           Recreate merge commits instead of flattening the history by replaying commits a merge commit introduces. Merge
           conflict resolutions or manual amendments to merge commits are not preserved.

           This uses the --interactive machinery internally, but combining it with the --interactive option explicitly is
           generally not a good idea unless you know what you are doing (see BUGS below).
```