### PR TITLE
Increase build timeout of coverage builds by 5 min

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -253,7 +253,7 @@
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '20m'
+            timeout: '25m'
             sub_job: 'coverage'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io


### PR DESCRIPTION
This trend shows that coverage builds for core tend to take close to 20min and we regularly run into timeouts: https://ci.centos.org/job/devtools-almighty-core-coverage/buildTimeTrend . That's why I want to increase the build timeout by 5 minutes.

@sbose78 has already written an email about this: https://www.redhat.com/archives/almighty-public/2017-January/msg00036.html