### PR TITLE
Increase build timeout for fabric8-planner by 5 min

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -260,7 +260,7 @@
             git_repo: fabric8-planner
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
-            timeout: '20m'
+            timeout: '25m'
         - '{ci_project}-{git_repo}':
             git_repo: almighty-devdoc
             ci_project: 'devtools'
@@ -291,7 +291,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: ui
-            timeout: '20m'
+            timeout: '25m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8io
             git_repo: fabric8-ui


### PR DESCRIPTION
We're seeing build timeouts lately.