### PR TITLE
Dont immediately return nodes when test runs fail

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -88,10 +88,17 @@
             && rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
             && /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?
-            cico node done $CICO_ssid
-            if [[ $rtn_code -eq 124 ]]; then
-               echo "BUILD TIMEOUT";
-            fi
+            if [ $rtn_code -eq 0 ]; then
+                cico node done $CICO_ssid
+            else
+                if [[ $rtn_code -eq 124 ]]; then
+                   echo "BUILD TIMEOUT";
+                   cico node done $CICO_ssid
+                else
+                    # fail mode gives us 12 hrs to debug the machine
+                    curl "http://admin.ci.centos.org:8080/Node/fail?key=${CICO_API_KEY}&ssid=${CICO_ssid}"
+                fi
+            fi 
             exit $rtn_code
 
 - job-template:
@@ -136,8 +143,13 @@
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && {ci_cmd}"
             rtn_code=$?
-            cico node done $CICO_ssid
-            if [ $rtn_code -eq 0 ]; then oc deploy {svc_name} --latest -n almighty ; fi
+            if [ $rtn_code -eq 0 ]; then
+              cico node done $CICO_ssid
+              oc deploy {svc_name} --latest -n almighty
+            else
+              # fail mode gives us 12 hrs to debug the machine
+              curl "http://admin.ci.centos.org:8080/Node/fail?key=${CICO_API_KEY}&ssid=${CICO_ssid}"
+            fi
             exit $rtn_code
             
 

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -235,7 +235,7 @@
             env > jenkins-env
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd -t "cd payload && '/bin/bash cico_build.sh && /bin/bash cico_deploy.sh'"
+            $ssh_cmd -t "cd payload && /bin/bash cico_build.sh"
             rtn_code=$?
             cico node done $CICO_ssid
             if [ $rtn_code -eq 0 ]; then oc deploy che --latest -n almighty ; fi


### PR DESCRIPTION
When a CI run fails, either for the per PR build or the master build, we can put the execution node into a 'fail' mode, this then gives us 12 hrs to login to the machine and look at the content etc.