### PR TITLE
Trigger master coverage build not from PR

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -158,10 +158,6 @@
 
 - job-template:
     name: '{ci_project}-{git_repo}-build-master-coverage'
-    triggers:
-      - github-pull-request:
-          status-context: "ci.centos.org PR build master (coverage)"
-          <<: *job_template_build_master_defaults
     <<: *job_template_defaults         
 
 - job-template:


### PR DESCRIPTION
The trigger for running the master coverage build cannot be "github pull request" for obvious reasons. That is why the jenkins job `devtools-almighty-core-build-master-coverage` was never started.