### PR TITLE
Add Obsidian Frontend and Backend to jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -318,3 +318,15 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: che-starter
             timeout: '20m'
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: obsidian-toaster
+            git_repo: generator-frontend
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            svc_name: obsidian-generator-frontend
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: obsidian-toaster
+            git_repo: generator-backend
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            svc_name: obsidian-generator-backend


### PR DESCRIPTION
This adds Obsidian Toaster services to CentOS CI builds.

This also depends on these 2 PRs to be merged:

- [x]  https://github.com/obsidian-toaster/generator-frontend/pull/23
- [x]  https://github.com/obsidian-toaster/generator-backend/pull/15