### PR TITLE
Fixed error when parsing the template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,3 +4,20 @@ image:https://ci.centos.org/buildStatus/icon?job=devtools-jjb-service[Jenkins,li
 
 This repository contains the definitions of the various jobs building
 on https://ci.centos.org.
+
+
+==== How to test your job definition ?
+
+You need to install `python-pip` and then use `pip` to install the
+`jenkins-job-builder` tool.
+
+```
+$ yum install python-pip
+$ pip install --user jenkins-job-builder
+```
+
+To test your job definition, you have to run the following command:
+
+```
+$ jenkins-jobs test devtools-ci-index.yaml name <JOB_NAME>
+```

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -627,7 +627,7 @@
             git_organization: almighty
             git_repo: keycloak
             ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            ci_cmd: 'git checkout f8-custom && /bin/bash cico_build_deploy.sh'
             timeout: '30m'
             branch: f8-custom
             svc_name: keycloak-server

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -144,7 +144,7 @@
             url: https://github.com/{git_organization}/{git_repo}.git
             shallow_clone: true
             branches:
-                - {branch}
+                - '{branch}'
     triggers:
         - github
     builders:
@@ -182,7 +182,7 @@
             url: https://github.com/{git_organization}/{git_repo}.git
             shallow_clone: true
             branches:
-                - {branch}
+                - '{branch}'
     triggers:
         - github
     builders:
@@ -223,7 +223,7 @@
             url: https://github.com/{git_organization}/{git_repo}.git
             shallow_clone: true
             branches:
-                - {branch}
+                - '{branch}'
     <<: *job_template_build_branch_defaults
 
 - job-template:

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -184,7 +184,7 @@
             branches:
                 - '{branch}'
     triggers:
-        - github
+        - githubprb
     builders:
         - shell: |
             # testing out the cico client
@@ -224,6 +224,11 @@
             shallow_clone: true
             branches:
                 - '{branch}'
+    triggers:
+      - github-pull-request:
+          white-list-target-branches:
+             - '{branch}'
+          <<: *github_pull_request_defaults
     <<: *job_template_build_branch_defaults
 
 - job-template:


### PR DESCRIPTION
When running `jenkins-jobs test devtools-ci-index.yaml name devtools-keycloak-build-branch`. I was getting the following error. So I believe the job was ignored.

```
INFO:jenkins_jobs.builder:Number of jobs generated:  1
INFO:jenkins_jobs.builder:Job name:  devtools-keycloak-build-branch
Traceback (most recent call last):
  File "/home/vagrant/.local/bin/jenkins-jobs", line 11, in <module>
    sys.exit(main())
  File "/home/vagrant/.local/lib/python2.7/site-packages/jenkins_jobs/cmd.py", line 191, in main
    execute(options, config)
  File "/home/vagrant/.local/lib/python2.7/site-packages/jenkins_jobs/cmd.py", line 380, in execute
    n_workers=1)
  File "/home/vagrant/.local/lib/python2.7/site-packages/jenkins_jobs/builder.py", line 378, in update_jobs
    output.write(job.output())
  File "/home/vagrant/.local/lib/python2.7/site-packages/jenkins_jobs/xml_config.py", line 54, in output
    out = minidom.parseString(XML.tostring(self.xml, encoding='UTF-8'))
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1126, in tostring
    ElementTree(element).write(file, encoding, method=method)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 820, in write
    serialize(write, self._root, encoding, qnames, namespaces)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 939, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 937, in _serialize_xml
    write(_escape_cdata(text, encoding))
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1075, in _escape_cdata
    _raise_serialization_error(text)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1052, in _raise_serialization_error
    "cannot serialize %r (type %s)" % (text, type(text).__name__)
TypeError: cannot serialize OrderedDict([('branch', None)]) (type OrderedDict)
```

ping @kbsingh 