### PR TITLE
Increase the timeout by 5minutes

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -471,7 +471,7 @@
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '30m'
+            timeout: '35m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io
             git_repo: fabric8-planner


### PR DESCRIPTION
Tests are taking longer and consequently failing due to timeout (set to 30min atm). While we detect the reason of this increment. We might need to move forward.

https://ci.centos.org/job/devtools-almighty-core-coverage/buildTimeTrend

