### PR TITLE
Switch to master branch for keycloak repo

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -890,13 +890,12 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: fabric8-ui-ngx-fabric8-wit
-        - '{ci_project}-{git_repo}-publish-branch':
+        - '{ci_project}-{git_repo}-build-master':
             git_organization: almighty
             git_repo: keycloak
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             timeout: '30m'
-            branch: f8-custom
             svc_name: keycloak-server
         - '{ci_project}-{git_repo}':
             git_organization: ldimaggi


### PR DESCRIPTION
We got the upstream changes merged so we can use `almighty/keycloak` master branch instead of `f8-custom`.

FYI: @alexeykazakov  