### PR TITLE
New job to build and publish dockerfiles for Che workspaces

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -921,3 +921,11 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: fabric8-ui-ngx-base
+        - '{ci_project}-{git_repo}-build-publish-images':
+            git_organization: redhat-developer
+            git_repo: che-dockerfiles
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_publish_images.sh'
+            timeout: '10m'
+            wrappers:
+                - che_credentials_wrapper


### PR DESCRIPTION
cc @dharmit @kbsingh @ibuziuk 

To run Che workspaces on OpenShift Online upstream Dockerfiles need to be patched. We have created a new repo for that: https://github.com/redhat-developer/che-dockerfiles

This PR is to create a new job to build and publish these images. Images are currently pushed to the following repositories:
- `rhche` (on DockerHub) 
- `registry.devshift.net/che`

Once we verify that this build process works properly we should probably publish to registry.centos.org too