### PR TITLE
auto-deploy osd-monitor

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -930,7 +930,7 @@
             git_repo: osd-monitor-poc
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build.sh'
-            svc_name: osd-monitor
+            template_name: osd-monitor.yml
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-ui
             git_repo: ngx-base


### PR DESCRIPTION
The osd-monitor repo now carries a deployment template for the unprivileged portions.  The pipeline should apply it after a build.