### PR TITLE
Increase the timeout for our coverage job

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -655,7 +655,7 @@
             git_repo: almighty-core
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '35m'
+            timeout: '45m'
         - '{ci_project}-{git_repo}':
             git_organization: fabric8io
             git_repo: fabric8-planner


### PR DESCRIPTION
We are still having timeout issues regarding our coverage tests... Let's increase the timeout to 45min to get them 🍏 . These tests are taking longer than before and that is a kind of shared feeling between computation being slower than before and a longer list of things to test.