### PR TITLE
[wip] add a second github url

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -489,6 +489,8 @@
     properties:
         - github:
             url: https://github.com/kbsingh/build-run-che/
+        - github:
+            url: https://github.com/eclipse/che/
     scm:
         - git:
             url: https://github.com/kbsingh/build-run-che.git


### PR DESCRIPTION
this seems to work in JJB and sets up the second set or properties, but needs testing to make sute its doing what we want it to do.

cc @lordofthejars 