### PR TITLE
Executes every 45 minutes but only run build if changes

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -497,10 +497,14 @@
                 - master
     triggers:
         - github
-        - timed: '20 00,12 * * *'
+        - timed: 'H/45 * * * *'
     builders:
         - shell: |
             # testing out the cico client
+            if [ "$GIT_PREVIOUS_COMMIT" = "$GIT_COMMIT" ]
+            then
+                exit 0
+            fi
             set +e
             set +x
             env > jenkins-env
@@ -934,5 +938,3 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: catapult
-
-


### PR DESCRIPTION
Executes every 45 minutes but only run build if changes by checking if previous build commit is the same as current one.

In https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin Environment variables section the variables used in the script are explained.