### PR TITLE
Use the build scripts moved in `rh_che` repo, and publish the Che JUnit test results in jenkins

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -577,6 +577,10 @@
             shallow_clone: true
             branches:
                 - master
+    publishers:
+        - junit:
+            results: /srv/che-build/rh-che/target/**/target/surefire-reports/*.xml
+
     triggers:
         - github
         - timed: '20 00,12 * * *'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -570,16 +570,15 @@
     node: devtools
     properties:
         - github:
-            url: https://github.com/kbsingh/build-run-che/
+            url: https://github.com/redhat-developer/rh-che/
     scm:
         - git:
-            url: https://github.com/kbsingh/build-run-che.git
+            url: https://github.com/redhat-developer/rh-che.git
             shallow_clone: true
             branches:
                 - master
     publishers:
-        - junit:
-            results: /srv/che-build/rh-che/target/**/target/surefire-reports/*.xml
+        - junit:./target/**/target/surefire-reports/*.xml
 
     triggers:
         - github


### PR DESCRIPTION
@kbsingh could you review this PR please ?

2 points should be confirmed:
- do we need to actually pull the results file back from the worker node
- the provided glob path for test results is absolute. The Jenkins plugin might require a path relative to the Job workspace root. 

Signed-off-by: David Festal <dfestal@redhat.com>