### PR TITLE
Correct filtering options in the `rsync` call

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -652,7 +652,7 @@
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
             $ssh_cmd -t "cd payload && /bin/bash cico_build.sh && /bin/bash cico_deploy.sh"
             rtn_code=$?
-            rsync -e "ssh $sshopts" -Ha --include 'target/**/target/surefire-reports/*.xml' --exclude '*' $CICO_hostname:payload $(pwd)/
+            rsync --progress -e "ssh $sshopts" -Ha --include='surefire-reports/***' --include='*/' --exclude='*' $CICO_hostname:payload/target/ $(pwd)/target
             cico node done $CICO_ssid
             exit $rtn_code
 


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>