### PR TITLE
Use the git short sha format with 7 characters instead of 6

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -237,7 +237,7 @@
               fi
               if [ "{template_name}" != "none" ]; then
                 if oc process -f {template_name} --parameters | grep IMAGE_TAG; then
-                    TAG=$(echo $GIT_COMMIT | cut -c1-6)
+                    TAG=$(echo $GIT_COMMIT | cut -c1-7)
                     PARAMETERS="IMAGE_TAG=$TAG"
                 fi
                 oc process -f {template_name} $PARAMETERS | oc apply -f - -n {prj_name}


### PR DESCRIPTION
For consistency, we should use the short git sha format and use 7 characters rather than 6 as it is done now. 

related to: https://github.com/almighty/almighty-jobs/issues/204