### PR TITLE
Deploy to appsec in promote-to-prod

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -946,7 +946,7 @@
     builders:
         - shell: |
             set -ex
-            PATH=$PATH:~/.local/bin /bin/bash ~/saasherder/fetch_and_apply.sh
+            PATH=$PATH:~/.local/bin APPSEC=true /bin/bash ~/saasherder/fetch_and_apply.sh
 
 - job:
     name: 'devtools-saasherder-test-master'


### PR DESCRIPTION
First need to get kubeconfigs in place.

Once they are there, this change will enable automatic deployment to *-appsec projects (https://github.com/openshiftio/saasherder/pull/14)