### PR TITLE
Fix fabric8-ui deployment by using default builder

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -446,51 +446,7 @@
 
     triggers:
         - github
-    svc_name: none
-    builders:
-        - shell: |
-            # testing out the cico client
-            set +e
-            export CICO_API_KEY=$(cat ~/duffy.key )
-            # get node
-            n=1
-            while true
-            do
-                cico_output=$(cico node get -f value -c ip_address -c comment)
-                if [ $? -eq 0 ]; then
-                    read CICO_hostname CICO_ssid <<< $cico_output
-                    if  [ ! -z "$CICO_hostname" ]; then
-                        # we got hostname from cico
-                        break
-                    fi
-                    echo "'cico node get' succeed, but can't get hostname from output"
-                fi
-                if [ $n -gt 5 ]; then
-                    # give up after 5 tries
-                    echo "giving up on 'cico node get'"
-                    exit 1
-                fi
-                echo "'cico node get' failed, trying again in 60s ($n/5)"
-                n=$[$n+1]
-                sleep 60
-            done
-            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
-            ssh_cmd="ssh $sshopts $CICO_hostname"
-            env > jenkins-env
-            $ssh_cmd yum -y install rsync
-            rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd -t "cd payload && {ci_cmd}"
-            rtn_code=$?
-            if [ $rtn_code -eq 0 ]; then
-              cico node done $CICO_ssid
-              if [ "{svc_name}" != "none" ]; then
-                oc deploy {svc_name} --latest
-              fi
-            else
-              # fail mode gives us 12 hrs to debug the machine
-              curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid"
-            fi
-            exit $rtn_code
+    <<: *job_template_build_defaults
 
 - job-template:
     name: '{ci_project}-fabric8-devdoc-build-master'
@@ -1095,7 +1051,7 @@
             git_repo: fabric8-ui
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
-            svc_name: f8ui
+            saas_git: saas-openshiftio
             timeout: '20m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: openshiftio
@@ -1177,7 +1133,6 @@
             git_repo: ngx-fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
-            svc_name: fabric8-ui-ngx-fabric8-wit
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services
             git_repo: keycloak-deployment


### PR DESCRIPTION
Unless there is any hidden connection between fabric8 cd and almighty-jobs, this will fix fabric8-ui deployments to stage (if there is any secret connection, it will still fix the deployment to stage, but might break PR deployments)

please let me know if you encounter any unexpected failures or missing automated comments in any of:

* fabric8-ui/fabric8-ui
* fabric8-ui/ngx-fabric8-wit
* fabric8-ui/ngx-login-client
* fabric8-ui/ngx-widgets

@joshuawilson 
