### PR TITLE
Use correct path to run the script for the end-to-end tests

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -862,7 +862,7 @@
             ssh_cmd="ssh $sshopts $CICO_hostname"
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd -t "cd payload && /bin/bash ee_tests/cico_run_EE_tests.sh https://openshift.io"
+            $ssh_cmd -t "cd payload/ee_tests && /bin/bash cico_run_EE_tests.sh https://openshift.io"
             rtn_code=$?
             cico node done $CICO_ssid
             exit $rtn_code


### PR DESCRIPTION
Len mentioned the end-to-end tests are broken. This new command should fix them,