### PR TITLE
Modify launchpad-templates job. Use build script.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1449,7 +1449,7 @@
             git_organization: openshiftio
             git_repo: launchpad-templates
             ci_project: 'devtools'
-            ci_cmd: 'echo "Nothing to build, just deploy nginx"'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-launchpad
             prj_name: launchpad-preview
         - '{ci_project}-{git_repo}':


### PR DESCRIPTION
Currently, the launchpad-template job does not run any script.
We want the launchpad-templates job to build using the build script mentioned in the PR.
The discussion around the need of building launchpad-templates via the Jenkins job can be found [here](https://github.com/openshiftio/launchpad-templates/pull/26)