### PR TITLE
Che stacks for osio should be build daily

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -773,27 +773,68 @@
 
 
 - job:
-    name: 'eclipse-che-build-openshift-connector'
+    name: 'eclipse-che-build-dockerfiles'
     wrappers:
         - che_credentials_wrapper
+        - registry_devshift_credentials
     defaults: global
     node: devtools
     properties:
         - github:
-            url: https://github.com/eclipse/che
+            url: https://github.com/redhat-developer/che-dockerfiles/
     scm:
         - git:
-            url: https://github.com/eclipse/che.git
+            url: https://github.com/redhat-developer/che-dockerfiles.git
             shallow_clone: true
             branches:
-                - openshift-connector
+                - master
     triggers:
         - github
+        - timed: '59 22 * * *'
+    timeout: '45m'
     builders:
-        - trigger-builds:
-            - project:
-                - "devtools-build-run-che-build-master"
-              current-parameters: true
+        - shell: |
+            # testing out the cico client
+            set +e
+            set +x
+            env > jenkins-env
+            cat $creds_config_file >> jenkins-env
+            export CICO_API_KEY=$(cat ~/duffy.key )
+            # get node
+            n=1
+            while true
+            do
+                cico_output=$(cico node get -f value -c ip_address -c comment)
+                if [ $? -eq 0 ]; then
+                    read CICO_hostname CICO_ssid <<< $cico_output
+                    if  [ ! -z "$CICO_hostname" ]; then
+                        # we got hostname from cico
+                        break
+                    fi
+                    echo "'cico node get' succeed, but can't get hostname from output"
+                fi
+                if [ $n -gt 5 ]; then
+                    # give up after 5 tries
+                    echo "giving up on 'cico node get'"
+                    exit 1
+                fi
+                echo "'cico node get' failed, trying again in 60s ($n/5)"
+                n=$[$n+1]
+                sleep 60
+            done
+            echo 'Using Host' $CICO_hostname
+            set -x
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            ssh_cmd="ssh $sshopts $CICO_hostname"
+            $ssh_cmd yum -y install rsync
+            rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
+            /usr/bin/timeout {timeout} $ssh_cmd -t "cd payload && /bin/bash cico_build_publish_images.sh"
+            rtn_code=$?
+            if [[ $rtn_code -eq 124 ]]; then
+               echo "BUILD TIMEOUT";
+            fi
+            cico node done $CICO_ssid
+            exit $rtn_code
 
 - job:
     name: 'eclipse-che-promotion'
@@ -1424,13 +1465,6 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             svc_name: fabric8-ui-ngx-base
-        - '{ci_project}-{git_repo}-build-che-credentials-master':
-            git_organization: redhat-developer
-            git_repo: che-dockerfiles
-            ci_project: 'devtools'
-            ci_cmd: '/bin/bash cico_build_publish_images.sh'
-            timeout: '10m'
-            svc_name: none
         - '{ci_project}-{git_repo}-generator-build-master':
             git_organization: openshiftio
             git_repo: launchpad-frontend


### PR DESCRIPTION
**What does this PR do**

- Add `timed` trigger for the build of https://github.com/redhat-developer/che-dockerfiles to run it daily
- Delete job `eclipse-che-build-openshift-connector` (upstream branch openshift-connector is not used anymore)