### PR TITLE
f8a: add worker scaler

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1808,3 +1808,18 @@
             deployment_units: 'stack-report-ui'
             deployment_configs: 'fabric8-analytics-stack-report-ui'
             timeout: '20m'
+        - '{ci_project}-{git_repo}-fabric8-analytics':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-scaler
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'
+        - '{ci_project}-{git_repo}-f8a-build-master':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-scaler
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            saas_git: saas-analytics
+            deployment_units: 'worker-scaler'
+            deployment_configs: 'f8a-worker-scaler'
+            timeout: '20m'


### PR DESCRIPTION
This service provides scaling forfabric8-workers using a script. Since openshift auto scaler does not support custom metrics.