### PR TITLE
cico scripts have been moved to .ci folder in rh-che repository

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -950,7 +950,7 @@
             ssh_cmd="ssh $sshopts $CICO_hostname"
             $ssh_cmd yum -y install rsync
             rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload
-            $ssh_cmd -t "cd payload && /bin/bash cico_build.sh && /bin/bash cico_deploy.sh"
+            $ssh_cmd -t "cd payload && /bin/bash .ci/cico_build.sh && /bin/bash .ci/cico_deploy.sh"
             rtn_code=$?
             rsync -e "ssh $sshopts" -Ha --include='surefire-reports/***' --include='*/' --exclude='*' $CICO_hostname:payload/ $(pwd)
             cico node done $CICO_ssid


### PR DESCRIPTION
Change-Id: Idadadaf17cbe6fac6364ffcd7e3e983ebdd49adb
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>