### PR TITLE
fix(test): add the refresh token for KC

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1108,6 +1108,9 @@
                 username: EE_TEST_USERNAME
                 password: EE_TEST_PASSWORD
             - text:
+                credential-id: "{kc_refresh_token_creds}"
+                kc-refresh-token: EE_TEST_KC_REFRESH_TOKEN
+            - text:
                 credential-id: "{oso_token_creds}"
                 variable: EE_TEST_OSO_TOKEN
     builders:
@@ -1644,6 +1647,7 @@
             test_suite: quickstartTest
             after: devtools-test-end-to-end-openshift.io-runTest
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             ee_test_start_time: '30 */2 * * *'
             timeout: 60m
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
@@ -1651,6 +1655,7 @@
             test_suite: chequickstartTest
             after: devtools-test-end-to-end-openshift.io-quickstartTest
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             timeout: 60m
             ee_test_start_time: '0 1-23/2 * * *'
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
@@ -1658,6 +1663,7 @@
             test_suite: runTest
             after: fabric8io-fabric8-test-build-master
             oso_token_creds: bca7a2b5-87b9-46bb-93a8-e66a05a5d7c6
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             ee_test_start_time: '0 */2 * * *'
             timeout: 60m
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
@@ -1665,6 +1671,7 @@
             test_suite: quickstartTest
             after: devtools-test-end-to-end-prod-preview.openshift.io-runTest
             oso_token_creds: bca7a2b5-87b9-46bb-93a8-e66a05a5d7c6
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             timeout: 60m
             ee_test_start_time: '30 */2 * * *'
         - 'devtools-test-end-to-end-{test_url}-{test_suite}':
@@ -1672,6 +1679,7 @@
             test_suite: chequickstartTest
             after: devtools-test-end-to-end-prod-preview.openshift.io-chequickstartTest
             oso_token_creds: bca7a2b5-87b9-46bb-93a8-e66a05a5d7c6
+            kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             timeout: 60m
             ee_test_start_time: '0 1-23/2 * * *'
         - '{ci_project}-{git_repo}-fabric8-analytics':


### PR DESCRIPTION
This is the KC token for a test user account - why do we need this?

* The test account runs tests all the time
* It has to periodically delete old Che workspaces
* It does through curl and the Che API
* And that API call requires the token

