### PR TITLE
Copy ~/artifacts.key to working directory, so it is rsynced to duffy

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -127,6 +127,7 @@
         - shell: |
             # testing out the cico client
             set +e
+            cp ~/artifacts.key .
             export CICO_API_KEY=$(cat ~/duffy.key )
             # get node
             n=1


### PR DESCRIPTION
machine.

This should enable rsyncing to artifacts.ci.centos.org directly from
duffy machine (useful for junit results, screenshots, ...).
Signed-off-by: rhopp <rhopp@dhcp-10-40-4-239.brq.redhat.com>