### PR TITLE
Removed publishers from che-functional-tests-template.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -968,11 +968,6 @@
                 credential-id: ac51aeb0-a436-4a50-a71d-aa6f99075398
                 username: OSIO_USERNAME
                 password: OSIO_PASSWORD
-    publishers:
-      - archive:
-           artifacts: './target/screenshots/*.*,./target/surefire-reports/**'
-           allow-empty: true
-           fingerprint: true
     <<: *job_template_defaults
 
 - job-template:


### PR DESCRIPTION
Publishing will be done directly from duffy machine using rsync to
artifacts.ci.centos.duffy.

Signed-off-by: rhopp <rhopp@dhcp-10-40-4-239.brq.redhat.com>