### PR TITLE
adds job for vscode-osio-auth extension

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1999,3 +1999,15 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
             prj_name: mattermost-preview
+          - '{ci_project}-{git_repo}':
+            git_organization: fabric8-analytics
+            git_repo: vscode-osio-auth
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'
+         - '{ci_project}-{git_repo}-build-master':
+            git_organization: fabric8-analytics
+            git_repo: vscode-osio-auth
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            timeout: '20m'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1935,13 +1935,13 @@
             deployment_units: 'worker-scaler'
             deployment_configs: 'f8a-worker-scaler'
             timeout: '20m'
-        - '{ci_project}-{git_repo}-fabric8-analytics':
+        - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-vscode-extension
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
-        - '{ci_project}-{git_repo}-f8a-build-master':
+        - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-analytics
             git_repo: fabric8-analytics-vscode-extension
             ci_project: 'devtools'

--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1999,13 +1999,13 @@
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
             prj_name: mattermost-preview
-          - '{ci_project}-{git_repo}':
+        - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: vscode-osio-auth
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'
             timeout: '20m'
-         - '{ci_project}-{git_repo}-build-master':
+        - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-analytics
             git_repo: vscode-osio-auth
             ci_project: 'devtools'


### PR DESCRIPTION
It adds job for new extension VSCode-osio-auth , for authorising external user to leverage OSIO services
- package extension
- prepublish extension
- It run integration tests on VSCode in headless mode

Signed-off-by: invinciblejai <mailjai.vardhan@gmail.com>