### PR TITLE
Update prj_name for chat.openshift.io jobs

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2081,7 +2081,7 @@
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}-{subdir}-build-master':
             git_organization: rhdt
             git_repo: chat-integrations
@@ -2089,7 +2089,7 @@
             ci_project: 'devtools'
             ci_cmd: 'cd github && /bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}-{subdir}-build-master':
             git_organization: rhdt
             git_repo: chat-integrations
@@ -2097,7 +2097,7 @@
             ci_project: 'devtools'
             ci_cmd: 'cd gitlab && /bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}-{subdir}-build-master':
             git_organization: rhdt
             git_repo: chat-integrations
@@ -2105,7 +2105,7 @@
             ci_project: 'devtools'
             ci_cmd: 'cd rssfeeds && /bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}-{subdir}-build-master':
             git_organization: rhdt
             git_repo: chat-integrations
@@ -2113,14 +2113,14 @@
             ci_project: 'devtools'
             ci_cmd: 'cd irc && /bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}-build-master':
             git_organization: rhdt
             git_repo: chat-push-proxy
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
             saas_git: saas-chat
-            prj_name: mattermost-preview
+            prj_name: chat-preview
         - '{ci_project}-{git_repo}':
             git_organization: fabric8-analytics
             git_repo: vscode-osio-auth


### PR DESCRIPTION
Make the chat jobs deploy to the `chat-preview` project instead of `mattermost-preview`