### PR TITLE
cicd for api-machine-stacks repository

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2060,3 +2060,18 @@
             deployment_units: '3scale-admin-gateway'
             deployment_configs: 'f8a-3scale-admin-gateway'
             timeout: '20m'
+        - '{ci_project}-{git_repo}-fabric8-analytics':
+            git_organization: fabric8-analytics
+            git_repo: api-machine-stacks
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '20m'
+        - '{ci_project}-{git_repo}-f8a-build-master':
+            git_organization: fabric8-analytics
+            git_repo: api-machine-stacks
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            saas_git: saas-analytics
+            deployment_units: 'api-machine-stacks'
+            deployment_configs: 'f8a-api-machine-stacks'
+            timeout: '20m'


### PR DESCRIPTION
This creates CICD for https://github.com/fabric8-analytics/api-machine-stacks repository.

This repository has an API server that performs necessary things for generating user's own custom stack. [POC phase]

https://docs.google.com/presentation/d/1H2Ws4qGZ4gkCRS3czsuCGUzWgkOtRdkgxDr-3393GCM/edit?ts=5a092a73#slide=id.g29b4b223b5_0_3