### PR TITLE
Add the `fabric8-tenant-che-migration` job.

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1495,6 +1495,13 @@
             timeout: '10m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services
+            git_repo: fabric8-tenant-che-migration
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            saas_git: saas-openshiftio
+            timeout: '10m'
+        - '{ci_project}-{git_repo}-build-master':
+            git_organization: fabric8-services
             git_repo: fabric8-admin-proxy
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'


### PR DESCRIPTION
This PR is to setup the CI build of the single-tenant to multi-tenant migration tool.