### PR TITLE
Remove the `saas` mention in the migration Ci Job, since it's not a dsaas service anymore

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1590,7 +1590,6 @@
             git_repo: fabric8-tenant-che-migration
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_build_deploy.sh'
-            saas_git: saas-openshiftio
             timeout: '10m'
         - '{ci_project}-{git_repo}-build-master':
             git_organization: fabric8-services


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>