### PR TITLE
Added Kronos base image repository to centos-ci

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2113,6 +2113,21 @@
             timeout: '30m'
         - '{ci_project}-{git_repo}-fabric8-analytics':
             git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-stack-analysis-base
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_run_tests.sh'
+            timeout: '30m'
+            image_name: 'fabric8-analytics/f8a-kronos-base'
+        - '{ci_project}-{git_repo}-f8a-build-master':
+            git_organization: fabric8-analytics
+            git_repo: fabric8-analytics-stack-analysis-base
+            ci_project: 'devtools'
+            ci_cmd: '/bin/bash cico_build_deploy.sh'
+            saas_git: saas-analytics
+            skip_deploy: 1
+            timeout: '30m'
+        - '{ci_project}-{git_repo}-fabric8-analytics':
+            git_organization: fabric8-analytics
             git_repo: fabric8-analytics-cvedb-s3-dump-docker
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_tests.sh'


### PR DESCRIPTION
This base image will considerably reduce the time required to build Kronos
as it requires installing quite a bit of Cpython dependencies which take time
to build.