### PR TITLE
test-end-to-end-prod-fabric8-analytics was missing SCM settings

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -671,6 +671,12 @@
     wrappers:
         - recommender_api_token_prod
         - ansicolor
+    scm:
+        - git:
+            url: https://github.com/{git_organization}/{git_repo}.git
+            shallow_clone: true
+            branches:
+                - master
     concurrent: false
     builders:
         - shell: |


### PR DESCRIPTION
This change should fix current failures