### PR TITLE
fix(test) the combination of after+scheduled jobs is creating multiple unwanted runs which can collide

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -2013,7 +2013,6 @@
         - 'devtools-test-end-to-end-ts-{test_url}-{test_suite}':
             test_url: openshift.io
             test_suite: chequickstartTest
-            after: devtools-test-end-to-end-ts-openshift.io-quickstartTest
             oso_token_creds: de0940f2-f31f-4186-85e2-37d42bddcf5b 
             kc_refresh_token_creds: 807b706e-c54f-48d5-be93-56525cf499f0
             ee_test_start_time: '55 */3 * * *'


### PR DESCRIPTION
The situation is that there are (3) jobs that are chained together. The result of the combination of after+scheduled job runs is that the 2nd job runs twice and the third job runs three times.

This PR is an attempt to remove the "after" link from the third job so that it only runs on the scheduled time.