### PR TITLE
added jarifibrahim user to admin list

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -75,6 +75,7 @@
         - surajssd
         - gastaldi
         - edewit
+        - jarifibrahim
 
 - github_pull_request_defaults: &github_pull_request_defaults
     name: 'github_pull_request_defaults'


### PR DESCRIPTION
This user contributes to the fabric8-wit repository, fabric8-ci needs to consider him as a collaborator so CI can proceed.
