### PR TITLE
update coverage timeout for fabric8-wit to 90 minutes

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -1593,7 +1593,7 @@
             git_repo: fabric8-wit
             ci_project: 'devtools'
             ci_cmd: '/bin/bash cico_run_coverage.sh'
-            timeout: '1h'
+            timeout: '90m'
         - '{ci_project}-{git_repo}':
             git_repo: fabric8-devdoc
             ci_project: 'devtools'


### PR DESCRIPTION
Jenkins coverage builds for WIT have started failing with timeout errors.  
The current average 55-60 minutes, and the last build failed as it was nearing the end.
This patch adds enough headroom so this shouldn't be an issue.