### PR TITLE
Add user "Preeticp" to list

### DIFF
--- a/devtools-ci-index.yaml
+++ b/devtools-ci-index.yaml
@@ -76,6 +76,7 @@
         - gastaldi
         - edewit
         - jarifibrahim
+        - Preeticp
 
 - github_pull_request_defaults: &github_pull_request_defaults
     name: 'github_pull_request_defaults'


### PR DESCRIPTION
https://github.com/fabric8-services/fabric8-wit/pull/1823 - this is the change proposed by https://github.com/Preeticp
Hence we need that user on the list to complete CI process. Otherwise, it throws `Change author is not a collaborator on the project, failing build until we support the [test] comment`. Also adding that user as collab on the repo.
  